### PR TITLE
Fixed alignment issue

### DIFF
--- a/x11/gtk2/gtk_wrapper.c
+++ b/x11/gtk2/gtk_wrapper.c
@@ -126,12 +126,24 @@ static gint orig_x, orig_y;
 static inline Bool
 XF86VidModeGetModeInfo(Display *d, int s, XF86VidModeModeInfo *info)
 {
-	XF86VidModeModeLine *line;
+	XF86VidModeModeLine line;
 
 	memset(info, 0, sizeof(*info));
-	line = (void *)((char *)info + sizeof(info->dotclock));
 
-	return XF86VidModeGetModeLine(d, s, (int *)&info->dotclock, line);
+	Bool ret = XF86VidModeGetModeLine(d, s, (int *)&info->dotclock, &line);
+	info->hdisplay = line.hdisplay;
+	info->hsyncstart = line.hsyncstart;
+	info->hsyncend = line.hsyncend;
+	info->htotal = line.htotal;
+	info->vdisplay = line.vdisplay;
+	info->vsyncstart = line.vsyncstart;
+	info->vsyncend = line.vsyncend;
+	info->vtotal = line.vtotal;
+	info->flags = line.flags;
+	info->privsize = line.privsize;
+	info->private = line.private;
+
+	return ret;
 }
 
 static int


### PR DESCRIPTION
On my 64-bit system, `private` is 64-bit aligned, and so `XF86VidModeModeInfo` has padding between `privsize` and `private` but `XF86VidModeModeLine` does not.  Therefore, you can't convert between them via pointer casting or `memcpy`; a manual copy of each member is needed.
