### PR TITLE
Fix an issue of (re)mounting fd in different type (2DD/2HD/1.44M).

### DIFF
--- a/fdd/fdd_d88.c
+++ b/fdd/fdd_d88.c
@@ -193,11 +193,45 @@ static void drvflush(FDDFILE fdd) {
 	}
 }
 
+
+static BRESULT fdd_diskaccess_d88_exact(FDDFILE fdd) {	// ver0.31 (fdd_diskaccess_d88)
+
+	UINT8	rpm;
+
+	rpm = fdc.rpm[fdc.us];
+	switch(fdd->inf.d88.fdtype_major) {
+		case DISKTYPE_2D:
+		case DISKTYPE_2DD:
+			if ((rpm) || (CTRL_FDMEDIA != DISKTYPE_2DD)) {
+				return(FAILURE);
+			}
+			break;
+
+		case DISKTYPE_2HD:
+			if (CTRL_FDMEDIA != DISKTYPE_2HD) {
+				return(FAILURE);
+			}
+			if ((fdd->inf.d88.fdtype_minor == 0) && (rpm)) {
+				return(FAILURE);
+			}
+			break;
+
+		default:
+			return(FAILURE);
+
+	}
+	return(SUCCESS);
+}
+
+
 static BRESULT trkseek(FDDFILE fdd, UINT track) {
 
 	D88TRK	trk;
 	BOOL	r;
 
+	if (fdd_diskaccess_d88_exact(fdd) == FAILURE) {
+		return(FAILURE);
+	}
 	trk = &d88trk;
 	if ((trk->fdd == fdd) && (trk->track == track) &&
 		(trk->type == CTRL_FDMEDIA)) {
@@ -309,34 +343,17 @@ BRESULT fddd88_eject(FDDFILE fdd) {
 }
 
 
-BRESULT fdd_diskaccess_d88(void) {									// ver0.31
+BRESULT fdd_diskaccess_d88(void) {
 
 	FDDFILE	fdd = fddfile + fdc.us;
-	UINT8	rpm;
 
-	rpm = fdc.rpm[fdc.us];
-	switch(fdd->inf.d88.fdtype_major) {
+	if (fdd->type == DISKTYPE_D88) switch(fdd->inf.d88.fdtype_major) {
 		case DISKTYPE_2D:
 		case DISKTYPE_2DD:
-			if ((rpm) || (CTRL_FDMEDIA != DISKTYPE_2DD)) {
-				return(FAILURE);
-			}
-			break;
-
 		case DISKTYPE_2HD:
-			if (CTRL_FDMEDIA != DISKTYPE_2HD) {
-				return(FAILURE);
-			}
-			if ((fdd->inf.d88.fdtype_minor == 0) && (rpm)) {
-				return(FAILURE);
-			}
-			break;
-
-		default:
-			return(FAILURE);
-
+			return (SUCCESS);
 	}
-	return(SUCCESS);
+	return(FAILURE);
 }
 
 BRESULT fdd_seek_d88(void) {

--- a/fdd/fdd_xdf.c
+++ b/fdd/fdd_xdf.c
@@ -7,6 +7,10 @@
 
 
 static const _XDFINFO supportxdf[] = {
+#if 1
+			{0, 160,  8, 2, DISKTYPE_2DD, 0},
+			{0, 160,  9, 2, DISKTYPE_2DD, 0},
+#endif
 #if 0
 			// 256
 			{0, 154, 26, 1, DISKTYPE_2HD, 0},
@@ -170,8 +174,7 @@ BRESULT fddxdf_eject(FDDFILE fdd) {
 
 BRESULT fddxdf_diskaccess(FDDFILE fdd) {
 
-	if ((fdd->type != DISKTYPE_BETA) ||
-		(CTRL_FDMEDIA != fdd->inf.xdf.disktype)) {
+	if (fdd->type != DISKTYPE_BETA) {
 		return(FAILURE);
 	}
 	return(SUCCESS);
@@ -295,6 +298,7 @@ BRESULT fddxdf_readid(FDDFILE fdd) {
 
 	fddlasterror = 0x00;
 	if ((!fdc.mf) ||
+		(CTRL_FDMEDIA != fdd->inf.xdf.disktype) ||
 		(fdc.rpm[fdc.us] != fdd->inf.xdf.rpm) ||
 		(fdc.crcn >= fdd->inf.xdf.sectors)) {
 		fddlasterror = 0xe0;


### PR DESCRIPTION
2DDのFDイメージをマウントしても（2DDからのブート時以外）読み書きできなかったので、暫定的に修正してみました。
ディスクモードと異なるタイプのイメージをセットしてもSENSEコマンドを受け付けるようにしています。
NEC版MS-DOS 3.3Dと6.2はこの修正でいけるようです。